### PR TITLE
restrict InternalFlattenList depth

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -12,11 +12,7 @@ type InternalFlattenList<T> =
   F extends null ? [A] | [A, C] | [A, C, E] :
   F extends [infer G, infer H] ?
   H extends null ? [A] | [A, C] | [A, C, E] | [A, C, E, G] :
-  H extends [infer I, infer J] ?
-  J extends null ? [A] | [A, C] | [A, C, E] | [A, C, E, G] | [A, C, E, G, I] :
-  J extends [infer K, infer L] ?
-  L extends null ? [A] | [A, C] | [A, C, E] | [A, C, E, G] | [A, C, E, G, I] | [A, C, E, G, I, K] :
-  [] : [] : [] : [] : [] : [] : [];
+  [] : [] : [] : [] : [];
 
 /**
  * Returns all valid key paths for a given type alias `T`.
@@ -29,11 +25,11 @@ export type KeyPath<T> = InternalFlattenList<InternalKeyList<T>>;
  */
 export type KeyPathValue<T, KP> =
   KP extends [] ? T :
-  KP extends [infer A] ? A extends keyof T ? T[A] : never : 
+  KP extends [infer A] ? A extends keyof T ? T[A] : never :
   KP extends [infer A, infer B] ? A extends keyof T ? B extends keyof T[A] ? T[A][B] : never : never :
   KP extends [infer A, infer B, infer C] ? A extends keyof T ? B extends keyof T[A] ? C extends keyof T[A][B] ? T[A][B][C] : never : never : never :
   KP extends [infer A, infer B, infer C, infer D] ? A extends keyof T ? B extends keyof T[A] ? C extends keyof T[A][B] ? D extends keyof T[A][B][C] ? T[A][B][C][D] : never : never : never : never :
   KP extends [infer A, infer B, infer C, infer D, infer E] ? A extends keyof T ? B extends keyof T[A] ? C extends keyof T[A][B] ? D extends keyof T[A][B][C] ? E extends keyof T[A][B][C][D] ? T[A][B][C][D][E] : never : never : never : never : never :
-  KP extends [infer A, infer B, infer C, infer D, infer E, infer F] ? A extends keyof T ? B extends keyof T[A] ? C extends keyof T[A][B] ? D extends keyof T[A][B][C] ? E extends keyof T[A][B][C][D] ? F extends keyof T[A][B][C][D][E] ? T[A][B][C][D][E][F] : never : never : never : never : never : never : 
+  KP extends [infer A, infer B, infer C, infer D, infer E, infer F] ? A extends keyof T ? B extends keyof T[A] ? C extends keyof T[A][B] ? D extends keyof T[A][B][C] ? E extends keyof T[A][B][C][D] ? F extends keyof T[A][B][C][D][E] ? T[A][B][C][D][E][F] : never : never : never : never : never : never :
   KP extends [infer A, infer B, infer C, infer D, infer E, infer F, infer G] ? A extends keyof T ? B extends keyof T[A] ? C extends keyof T[A][B] ? D extends keyof T[A][B][C] ? E extends keyof T[A][B][C][D] ? F extends keyof T[A][B][C][D][E] ? G extends keyof T[A][B][C][D][E][F] ? T[A][B][C][D][E][F][G] : never : never : never : never : never : never : never :
   never;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "useful-types",
-  "version": "0.2.1",
+  "version": "0.3.0",
   "description": "Some useful higher-order types",
   "repository": "https://github.com/garbles/useful-types",
   "main": "index.js",


### PR DESCRIPTION
remove the depth from InternalFlattenList to stop this typescript error:

> Type instantiation is excessively deep and possibly infinite.

I noticed this on [flag](https://github.com/garbles/flag) with this definition:

```
const useFlag = <KP extends KeyPath<T>>(keyPath: KP): KeyPathValue<T, KP> => {
```